### PR TITLE
Fade intersection labels and add The Almanack life pro tips section

### DIFF
--- a/almanack/css/almanack.css
+++ b/almanack/css/almanack.css
@@ -1,0 +1,96 @@
+:root {
+  --bg-dark: #0a0a0b;
+  --bg-light: #ffffff;
+  --bg-light-alt: #f8fafc;
+  --bg-warm: #fffbf5;
+  --text-dark: #1e293b;
+  --text-dark-secondary: #475569;
+  --text-muted: #64748b;
+  --accent-amber: #d97706;
+  --accent-amber-light: #fbbf24;
+  --accent-blue: #3b82f6;
+  --accent-violet: #8b5cf6;
+  --gradient-primary: linear-gradient(135deg, #3b82f6, #8b5cf6);
+  --gradient-warm: linear-gradient(135deg, #d97706, #ea580c);
+  --border-light: #e2e8f0;
+  --border-warm: #fde68a;
+  --shadow-md: 0 4px 6px -1px rgba(0,0,0,0.1);
+  --shadow-lg: 0 10px 15px -3px rgba(0,0,0,0.1);
+  --radius-sm: 6px;
+  --radius-md: 12px;
+  --radius-full: 9999px;
+  --font-sans: 'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+  --font-serif: 'Georgia','Times New Roman',serif;
+  --font-mono: 'JetBrains Mono','Fira Code',monospace;
+  --max-width: 900px;
+  --nav-height: 72px;
+}
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth;-webkit-font-smoothing:antialiased}
+body{font-family:var(--font-sans);font-size:16px;line-height:1.7;color:var(--text-dark);background:var(--bg-warm)}
+a{color:inherit;text-decoration:none}
+ul,ol{list-style:none}
+button{font-family:inherit;cursor:pointer;border:none;background:none}
+
+/* Nav */
+.alm-nav{position:fixed;top:0;left:0;right:0;z-index:1000;height:var(--nav-height);display:flex;align-items:center;background:rgba(255,251,245,0.95);backdrop-filter:blur(20px);border-bottom:1px solid var(--border-light)}
+.alm-nav-inner{width:100%;max-width:var(--max-width);margin:0 auto;padding:0 24px;display:flex;align-items:center;justify-content:space-between}
+.alm-nav-logo{font-size:1.1rem;font-weight:700;color:var(--text-dark);letter-spacing:-0.02em}
+.alm-nav-logo span{color:var(--accent-amber)}
+.alm-nav-links{display:flex;align-items:center;gap:20px}
+.alm-nav-links a{font-size:.85rem;font-weight:500;color:var(--text-muted);transition:color .2s}
+.alm-nav-links a:hover{color:var(--text-dark)}
+
+/* Hero */
+.alm-hero{padding:120px 24px 48px;max-width:var(--max-width);margin:0 auto;text-align:center}
+.alm-hero-icon{font-size:2.5rem;margin-bottom:16px}
+.alm-hero h1{font-size:clamp(2rem,4vw,3rem);font-weight:800;letter-spacing:-0.03em;margin-bottom:12px}
+.alm-hero h1 span{background:var(--gradient-warm);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text}
+.alm-hero p{color:var(--text-muted);font-size:1rem;max-width:560px;margin:0 auto;line-height:1.7}
+
+/* Controls */
+.alm-controls{max-width:var(--max-width);margin:0 auto;padding:32px 24px;display:flex;gap:12px;flex-wrap:wrap;align-items:center}
+.alm-search{position:relative;flex:1;min-width:200px}
+.alm-search input{width:100%;padding:10px 14px 10px 40px;border:1px solid var(--border-light);border-radius:var(--radius-full);font-size:.875rem;font-family:var(--font-sans);background:white;outline:none;transition:border .2s}
+.alm-search input:focus{border-color:var(--accent-amber)}
+.alm-search i{position:absolute;left:14px;top:50%;transform:translateY(-50%);color:var(--text-muted);font-size:.85rem}
+.alm-age-filters{display:flex;gap:6px;flex-wrap:wrap}
+.age-btn{padding:5px 14px;border-radius:var(--radius-full);font-size:.75rem;font-weight:600;background:white;color:var(--text-muted);border:1px solid var(--border-light);transition:all .2s}
+.age-btn:hover,.age-btn.active{background:var(--accent-amber);color:white;border-color:var(--accent-amber)}
+.alm-count{font-family:var(--font-mono);font-size:.75rem;color:var(--text-muted);padding:8px 0}
+
+/* Tips */
+.alm-tips{max-width:var(--max-width);margin:0 auto;padding:0 24px 80px}
+.tip-card{background:white;border:1px solid var(--border-light);border-radius:var(--radius-md);padding:32px;margin-bottom:20px;transition:all .3s ease;position:relative;overflow:hidden}
+.tip-card:hover{box-shadow:var(--shadow-lg);border-color:transparent;transform:translateY(-2px)}
+.tip-card::before{content:'';position:absolute;top:0;left:0;width:4px;height:100%;background:var(--gradient-warm);border-radius:4px 0 0 4px}
+.tip-number{font-family:var(--font-mono);font-size:.7rem;color:var(--accent-amber);font-weight:600;letter-spacing:.1em;text-transform:uppercase;margin-bottom:8px}
+.tip-title{font-size:1.35rem;font-weight:700;color:var(--text-dark);margin-bottom:8px;letter-spacing:-0.02em;line-height:1.3}
+.tip-meta{display:flex;gap:8px;align-items:center;margin-bottom:16px;flex-wrap:wrap}
+.tip-age{display:inline-flex;align-items:center;gap:4px;padding:3px 10px;border-radius:var(--radius-full);font-size:.7rem;font-weight:600;background:rgba(217,119,6,0.1);color:var(--accent-amber);border:1px solid rgba(217,119,6,0.2)}
+.tip-tag{padding:3px 10px;border-radius:var(--radius-full);font-size:.7rem;font-weight:500;background:var(--bg-light-alt);color:var(--text-muted);border:1px solid var(--border-light)}
+.tip-content{font-family:var(--font-serif);font-size:1.05rem;line-height:1.85;color:var(--text-dark-secondary)}
+.tip-content p{margin-bottom:16px}
+.tip-content p:last-child{margin-bottom:0}
+
+.no-tips{text-align:center;padding:60px 24px;color:var(--text-muted);font-size:1rem}
+
+/* Footer */
+.alm-footer{background:var(--bg-dark);padding:32px 0;text-align:center}
+.alm-footer p{font-size:.8rem;color:var(--text-muted);max-width:100%;text-align:center;margin:0 auto}
+
+/* How to add */
+.alm-howto{max-width:var(--max-width);margin:0 auto;padding:0 24px 60px}
+.alm-howto-card{background:white;border:1px solid var(--border-light);border-radius:var(--radius-md);padding:28px;margin-top:24px}
+.alm-howto-card h3{font-size:1rem;margin-bottom:12px;color:var(--text-dark)}
+.alm-howto-card ol{list-style:decimal;padding-left:20px}
+.alm-howto-card li{font-size:.875rem;color:var(--text-dark-secondary);margin-bottom:8px;line-height:1.6}
+.alm-howto-card code{font-family:var(--font-mono);font-size:.8em;padding:2px 6px;background:var(--bg-light-alt);border-radius:4px;border:1px solid var(--border-light)}
+.alm-howto-card pre{background:#1e293b;color:#e2e8f0;padding:16px;border-radius:var(--radius-sm);overflow-x:auto;margin:12px 0;font-size:.8rem;line-height:1.5;font-family:var(--font-mono)}
+
+@media(max-width:768px){
+  .alm-controls{flex-direction:column}
+  .alm-search{min-width:100%}
+  .tip-card{padding:24px}
+  .alm-nav-links .hide-mobile{display:none}
+}

--- a/almanack/index.html
+++ b/almanack/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>The Almanack | Aakash Shah</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+  <link rel="stylesheet" href="css/almanack.css">
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="alm-nav">
+    <div class="alm-nav-inner">
+      <a href="../" class="alm-nav-logo">aakash<span>shah</span></a>
+      <div class="alm-nav-links">
+        <a href="../blog/" class="hide-mobile">Blog</a>
+        <a href="../#about" class="hide-mobile">Portfolio</a>
+        <a href="#howto">How to add</a>
+      </div>
+    </div>
+  </nav>
+
+  <!-- Hero -->
+  <div class="alm-hero">
+    <div class="alm-hero-icon">&#128218;</div>
+    <h1>The <span>Almanack</span></h1>
+    <p>Life pro tips and hard-earned lessons on becoming financially sound, spatially aware, and genuinely mature — collected over the years so you don't have to learn them the hard way.</p>
+  </div>
+
+  <!-- Controls -->
+  <div class="alm-controls">
+    <div class="alm-search">
+      <i class="fa-solid fa-magnifying-glass"></i>
+      <input type="text" id="alm-search" placeholder="Search tips...">
+    </div>
+    <div class="alm-age-filters" id="age-filters"></div>
+  </div>
+  <div style="max-width:900px;margin:0 auto;padding:0 24px 12px">
+    <span class="alm-count" id="tip-count"></span>
+  </div>
+
+  <!-- Tips -->
+  <div id="tips-container" class="alm-tips">
+    <div class="no-tips">Loading tips...</div>
+  </div>
+
+  <!-- How to add -->
+  <div class="alm-howto" id="howto">
+    <div class="alm-howto-card">
+      <h3>How to add a new tip</h3>
+      <ol>
+        <li>Open <code>almanack/tips.json</code> in your repo.</li>
+        <li>Copy the template below and add it to the <code>"tips"</code> array.</li>
+        <li>Commit and push. The page auto-renders from the JSON — no HTML editing needed.</li>
+      </ol>
+      <pre>{
+  "id": "your-tip-slug",
+  "title": "Your Tip Title",
+  "age": "25-30",
+  "tags": ["finance", "mindset"],
+  "content": "Your tip content goes here. Use plain text. Multiple sentences work great. Keep it real."
+}</pre>
+      <p style="font-size:.8rem;color:#64748b;margin-top:12px"><strong>Age ranges:</strong> Use formats like <code>18-22</code>, <code>22-28</code>, <code>28-35</code>, <code>35-45</code>, <code>45+</code>. The filter buttons auto-generate from whatever you use.</p>
+    </div>
+  </div>
+
+  <!-- Footer -->
+  <footer class="alm-footer">
+    <p>Aakash Shah &bull; Austin, TX</p>
+  </footer>
+
+  <script src="js/almanack.js"></script>
+</body>
+</html>

--- a/almanack/js/almanack.js
+++ b/almanack/js/almanack.js
@@ -1,0 +1,98 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const tipsContainer = document.getElementById('tips-container');
+  const searchInput = document.getElementById('alm-search');
+  const ageContainer = document.getElementById('age-filters');
+  const countEl = document.getElementById('tip-count');
+  if (!tipsContainer) return;
+
+  let tips = [];
+  let activeAge = 'all';
+
+  // Fetch tips
+  try {
+    const res = await fetch('tips.json');
+    const data = await res.json();
+    tips = data.tips || [];
+  } catch (e) {
+    tipsContainer.innerHTML = '<div class="no-tips">Could not load tips.</div>';
+    return;
+  }
+
+  // Collect unique age ranges
+  const ageRanges = new Set();
+  tips.forEach(t => { if (t.age) ageRanges.add(t.age); });
+
+  // Render age filter buttons
+  if (ageContainer) {
+    let html = '<button class="age-btn active" data-age="all">All Ages</button>';
+    // Sort age ranges
+    const sorted = [...ageRanges].sort((a, b) => {
+      const aNum = parseInt(a.split('-')[0] || a.replace('+', ''));
+      const bNum = parseInt(b.split('-')[0] || b.replace('+', ''));
+      return aNum - bNum;
+    });
+    sorted.forEach(age => {
+      html += `<button class="age-btn" data-age="${age}">${age}</button>`;
+    });
+    ageContainer.innerHTML = html;
+    ageContainer.querySelectorAll('.age-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        ageContainer.querySelectorAll('.age-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        activeAge = btn.dataset.age;
+        render();
+      });
+    });
+  }
+
+  // Search
+  if (searchInput) {
+    searchInput.addEventListener('input', () => render());
+  }
+
+  function render() {
+    const query = (searchInput ? searchInput.value : '').toLowerCase().trim();
+    const filtered = tips.filter(t => {
+      const matchAge = activeAge === 'all' || t.age === activeAge;
+      const matchSearch = !query ||
+        t.title.toLowerCase().includes(query) ||
+        t.content.toLowerCase().includes(query) ||
+        (t.tags || []).some(tag => tag.toLowerCase().includes(query));
+      return matchAge && matchSearch;
+    });
+
+    if (countEl) {
+      countEl.textContent = `${filtered.length} tip${filtered.length !== 1 ? 's' : ''}`;
+    }
+
+    if (filtered.length === 0) {
+      tipsContainer.innerHTML = '<div class="no-tips">No tips found for this filter.</div>';
+      return;
+    }
+
+    tipsContainer.innerHTML = filtered.map((t, i) => {
+      // Convert newlines in content to paragraphs
+      const paragraphs = t.content.split('\n').filter(Boolean).map(p => `<p>${escapeHtml(p)}</p>`).join('');
+
+      return `
+        <div class="tip-card">
+          <div class="tip-number">Tip #${tips.indexOf(t) + 1}</div>
+          <h2 class="tip-title">${escapeHtml(t.title)}</h2>
+          <div class="tip-meta">
+            ${t.age ? `<span class="tip-age"><i class="fa-solid fa-calendar" style="font-size:.6rem"></i> Age ${t.age}</span>` : ''}
+            ${(t.tags || []).map(tag => `<span class="tip-tag">${tag}</span>`).join('')}
+          </div>
+          <div class="tip-content">${paragraphs}</div>
+        </div>
+      `;
+    }).join('');
+  }
+
+  function escapeHtml(str) {
+    const div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+  }
+
+  render();
+});

--- a/almanack/tips.json
+++ b/almanack/tips.json
@@ -1,0 +1,13 @@
+{
+  "title": "The Almanack",
+  "subtitle": "A compendium of life pro tips for becoming a mature, financially sound, and spatially aware man — early.",
+  "tips": [
+    {
+      "id": "marry-early",
+      "title": "Marry early, make kids early",
+      "age": "22-28",
+      "tags": ["relationships", "life-planning", "family"],
+      "content": "There's a compounding effect to starting a family early that nobody talks about. When you marry and have kids in your mid-twenties, you grow up alongside your children. By the time they're teenagers, you're still young enough to be active, relatable, and financially hitting your stride. By 50, your kids are independent adults — and you still have decades of energy and freedom ahead. The math works: early commitment compounds into long-term freedom. Most people optimize for freedom in their twenties and end up scrambling for stability in their forties. Flip the script."
+    }
+  ]
+}

--- a/css/modern.css
+++ b/css/modern.css
@@ -368,7 +368,7 @@ p {
   width: 320px;
   height: 320px;
   border-radius: 50%;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.04);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -378,11 +378,11 @@ p {
 
 .intersection-circle .circle-label {
   font-family: var(--font-mono);
-  font-size: 0.7rem;
-  font-weight: 600;
+  font-size: 0.65rem;
+  font-weight: 500;
   letter-spacing: 0.15em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.5);
+  color: rgba(255, 255, 255, 0.08);
   position: absolute;
   white-space: nowrap;
 }

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
         <a href="#awards">Awards</a>
         <a href="#education">Education</a>
         <a href="#contact">Contact</a>
+        <a href="almanack/">Almanack</a>
         <a href="blog/" class="nav-cta">Blog</a>
       </div>
       <div class="nav-toggle" aria-label="Toggle navigation">
@@ -540,6 +541,7 @@
       <h2>Thoughts on AI, product, and engineering</h2>
       <p>I write about building AI products, the intersection of technology and user adoption, and lessons from the trenches of product management in life sciences.</p>
       <a href="blog/" class="btn btn-light">Visit the blog <i class="fa-solid fa-arrow-right" style="font-size:0.8rem"></i></a>
+      <a href="almanack/" class="btn btn-outline" style="border-color:#e2e8f0;color:#475569;margin-left:8px">The Almanack <i class="fa-solid fa-book" style="font-size:0.8rem"></i></a>
     </div>
   </section>
 


### PR DESCRIPTION
- Faded Venn diagram circle labels to ~8% opacity so they act as subtle background texture without competing with hero text
- Added The Almanack: a JSON-driven life pro tips compendium with search, age-range filtering, warm design, and dead-simple workflow (just edit tips.json and commit — page auto-renders)
- First tip: "Marry early, make kids early"
- Added Almanack link to main site nav and CTA section

https://claude.ai/code/session_013daqJh4zxdhAvS58raCrBF